### PR TITLE
A11y: Required attr, ARIA Fields for Invalid & Error Message

### DIFF
--- a/packages/ember-principled-forms/addon/components/form-field/component.ts
+++ b/packages/ember-principled-forms/addon/components/form-field/component.ts
@@ -13,6 +13,8 @@ import { isNone } from '@ember/utils';
 
 type StringInputType = Type.color | Type.email | Type.password | Type.text;
 
+export type HTMLAttribute = string | undefined | boolean | number;
+
 const noop = (..._args: any[]) => {};
 
 // From _.isString, simplified very slightly.
@@ -68,10 +70,27 @@ export default class FormField<T> extends Component {
   get isInvalid() {
     return isInvalid(this.model.validity);
   }
+  
+  @computed('model.isRequired')
+  get required(): HTMLAttribute {
+    return this.model.isRequired ? true : undefined;
+  }
+
+  @computed('isInvalid')
+  get ariaInvalid(): HTMLAttribute {
+    const isValid = !this.isInvalid;
+    return isValid ? undefined : "true";
+  }
 
   // DISCUSS: What other useful defaults can we apply?
   // e.g. an ARIA object
   id: string = defaultTo(this.id, `form-field-${this.model.type}-${this.label}`);
+  errorId: string = defaultTo(`${this.id}-error`, `form-field-${this.model.type}-${this.label}-error`);
+
+  @computed('isInvalid')
+  get ariaDescribedBy(): HTMLAttribute {
+    return this.isInvalid ? this.errorId : undefined;
+  }
 
   onChange: (newValue: T) => void = defaultTo(this.onChange, noop);
   onInput: (newValue: T) => void = defaultTo(this.onInput, noop);

--- a/packages/ember-principled-forms/addon/components/form-field/template.hbs
+++ b/packages/ember-principled-forms/addon/components/form-field/template.hbs
@@ -5,6 +5,10 @@
       isInvalid=this.isInvalid
       label=label
       model=model
+      errorId=this.errorId
+      required=required
+      ariaInvalid=ariaInvalid
+      ariaDescribedBy=ariaDescribedBy
       onChange=(action 'handleChange' value='target.value')
       onInput=(action 'handleInput' value='target.value')
   )}}
@@ -16,16 +20,19 @@
   </label>
 
   <input
+      id={{this.id}}
       type={{model.type}}
       oninput={{action 'handleInput' value='target.value'}}
       onchange={{action 'handleChange' value='target.value'}}
-      value={{this.user.name.value}}
       class={{inputClass}}
       value={{model.value}}
+      required={{required}}
+      aria-invalid={{ariaInvalid}}
+      aria-describedby={{ariaDescribedBy}}
   />
 
   {{#if this.isInvalid}}
-    <span class={{errorClass}}>{{model.validity.reason}}</span>
+    <span class={{errorClass}} id={{this.errorId}}>{{model.validity.reason}}</span>
   {{/if}}
 
 {{/if}}

--- a/packages/ember-principled-forms/package.json
+++ b/packages/ember-principled-forms/package.json
@@ -22,10 +22,10 @@
     "postpublish": "ember ts:clean"
   },
   "dependencies": {
+    "@olo/principled-forms": "0.1.3",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.3",
     "ember-decorators": "^2.0.0",
-    "@olo/principled-forms": "0.1.3",
     "true-myth": "2.0.0"
   },
   "devDependencies": {
@@ -36,6 +36,7 @@
     "@types/qunit": "^2.5.0",
     "@types/rsvp": "^4.0.1",
     "broccoli-asset-rev": "^2.4.5",
+    "ember-a11y-testing": "^0.5.2",
     "ember-cli": "~3.1.2",
     "ember-cli-addon-docs": "^0.4.1",
     "ember-cli-addon-docs-yuidoc": "^0.2.0",

--- a/packages/ember-principled-forms/tests/integration/components/form-field-test.ts
+++ b/packages/ember-principled-forms/tests/integration/components/form-field-test.ts
@@ -3,6 +3,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+
 import Form from '@olo/principled-forms/form';
 import { Field } from '@olo/principled-forms/field';
 
@@ -26,16 +28,28 @@ module('Integration | Component | form-field', function(hooks) {
     this.setProperties({ model, onInput: noop, onChange: noop });
 
     await render(hbs`{{form-field label='Name' model=this.model.name onInput=this.onInput}}`);
+    const optionalInput = (this.element.querySelector('input') as HTMLInputElement);
+    const optionalInputLabel = (this.element.querySelector('label') as HTMLLabelElement);
     assert.ok(
-      (this.element.querySelector('input') as HTMLInputElement).value === '',
+      optionalInput.value === '',
       'optional field value renders'
     );
+    assert.equal(optionalInputLabel.htmlFor, optionalInput.id, 'label is connected to input');
+    assert.notOk(optionalInput.hasAttribute('required'), 'optional input does not have required attr');
+    assert.notOk(optionalInput.hasAttribute('aria-invalid'), 'valid input has no invalid state');
+    assert.notOk(optionalInput.hasAttribute('aria-describedby'), 'valid input has not described-by');
 
-    await render(hbs`{{form-field label='Name' model=this.model.age onInput=this.onInput}}`);
+    await a11yAudit();
+
+    await render(hbs`{{form-field label='Age' model=this.model.age onInput=this.onInput}}`);
+    const requiredInput = (this.element.querySelector('input') as HTMLInputElement);
     assert.ok(
-      (this.element.querySelector('input') as HTMLInputElement).value === age.value!.toString(),
+      requiredInput.value === age.value!.toString(),
       'required field value renders'
     );
+    assert.ok(requiredInput.hasAttribute('required'), 'required field is set to true')
+
+    await a11yAudit();
 
     // Template block usage:
     const label = 'wat';
@@ -47,5 +61,47 @@ module('Integration | Component | form-field', function(hooks) {
     `);
 
     assert.equal(this.element.textContent!.trim(), label, 'yields field model back out');
+
+    await a11yAudit();
+  });
+
+  test('error state is correct', async function(assert) {
+    const name = Field.validate(Field.required<string>());
+
+    const noop = () => {};
+    this.setProperties({ name, onInput: noop, onChange: noop });
+
+    await render(hbs`{{form-field label='Name' model=this.name onInput=this.onInput}}`);
+    const nameInput = (this.element.querySelector('input') as HTMLInputElement);
+    const errorSpan = (this.element.querySelector('span') as HTMLElement);
+
+    assert.ok(errorSpan, 'error exists');
+    assert.ok(nameInput.getAttribute('aria-invalid'), 'invalid input has aria-invalid true');
+    assert.equal(nameInput.getAttribute('aria-describedby'), errorSpan.id, 'valid input has error id described-by');
+    assert.equal(errorSpan.textContent!.trim(), 'field is required', 'displays required error');
+
+    await a11yAudit();
+
+    // Block Format
+    await render(hbs`
+      {{#form-field label='Name' model=this.name onInput=this.onInput as |field|}}
+        <input
+          id={{field.id}}
+          value={{field.model.value}}
+          aria-invalid={{field.ariaInvalid}}
+          aria-describedby={{field.ariaDescribedBy}}
+        />
+
+        {{#if field.isInvalid}}
+          <span class={{errorClass}} id={{field.errorId}}>{{field.model.validity.reason}}</span>
+        {{/if}}
+      {{/form-field}}
+    `);
+
+    const blockNameInput = (this.element.querySelector('input') as HTMLInputElement);
+    const blockErrorSpan = (this.element.querySelector('span') as HTMLElement);
+    assert.ok(blockNameInput.getAttribute('aria-invalid'), 'block | invalid input has aria-invalid true');
+    assert.equal(blockNameInput.getAttribute('aria-describedby'), blockErrorSpan.id, 'block | valid input has error id described-by');
+    assert.equal(blockErrorSpan.textContent!.trim(), 'field is required', 'block | displays required error');
   });
 });

--- a/packages/ember-principled-forms/yarn.lock
+++ b/packages/ember-principled-forms/yarn.lock
@@ -554,6 +554,10 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
+axe-core@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.6.1.tgz#28772c4f76966d373acda35b9a409299dc00d1b5"
+
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -2866,6 +2870,16 @@ electron-to-chromium@^1.3.30:
   version "1.3.44"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.44.tgz#ef6b150a60d523082388cadad88085ecd2fd4684"
 
+ember-a11y-testing@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-0.5.2.tgz#0ee555824a8e8181c55470e261b88dad4fdac721"
+  dependencies:
+    axe-core "^2.6.1"
+    broccoli-funnel "^2.0.1"
+    ember-cli-babel "^6.8.2"
+    ember-cli-version-checker "^2.1.0"
+    ember-get-config "^0.2.4"
+
 ember-ace@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-ace/-/ember-ace-1.3.1.tgz#b690cd1fe09a65a264dec40f9a54050af982a8da"
@@ -3631,6 +3645,13 @@ ember-fetch@^3.4.4:
     ember-cli-babel "^6.8.2"
     node-fetch "^2.0.0-alpha.9"
     whatwg-fetch "^2.0.3"
+
+ember-get-config@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^6.3.0"
 
 ember-getowner-polyfill@^2.0.1:
   version "2.2.0"


### PR DESCRIPTION
Fields added:

- label `for`
- input `required`
- input `aria-invalid`
- input `aria-describedby`
- error span `id`