### PR TITLE
Ember 3.6: Move Property state to init

### DIFF
--- a/packages/ember-principled-forms/addon/components/form-field/component.ts
+++ b/packages/ember-principled-forms/addon/components/form-field/component.ts
@@ -64,6 +64,8 @@ function parseValue(value: string, type: Type): string | number | boolean | Date
 @tagName('')
 @layout(template)
 export default class FormField<T> extends Component {
+  id!: string;
+  errorId!: string;
   readonly label!: string;
   readonly model!: Field<T>;
 
@@ -87,25 +89,26 @@ export default class FormField<T> extends Component {
     return !this.isInvalid ? undefined : 'true';
   }
 
-  // DISCUSS: What other useful defaults can we apply?
-  // e.g. an ARIA object
-  id: string = defaultTo(this.id, `form-field-${this.model.type}-${this.label}`);
-  errorId: string = defaultTo(
-    `${this.id}-error`,
-    `form-field-${this.model.type}-${this.label}-error`
-  );
-
   @computed('isInvalid')
   get ariaDescribedBy(): HTMLAttribute {
     return this.isInvalid ? this.errorId : undefined;
   }
 
-  onChange: (newValue: T) => void = defaultTo(this.onChange, noop);
-  onInput: (newValue: T) => void = defaultTo(this.onInput, noop);
+  onChange!: (newValue: T) => void;
+  onInput!: (newValue: T) => void;
 
-  constructor() {
-    super(...arguments);
+  init() {
+    super.init();
 
+    // DISCUSS: What other useful defaults can we apply?
+    // e.g. an ARIA object
+    this.id = defaultTo(this.id, `form-field-${this.model.type}-${this.label}`);
+    this.errorId = defaultTo(
+      `${this.id}-error`,
+      `form-field-${this.model.type}-${this.label}-error`
+    );
+    this.onChange = defaultTo(this.onChange, noop);
+    this.onInput = defaultTo(this.onInput, noop);
     assert(`\`model\` is required on '${this.id}'`, !isNone(this.model));
     assert(`\`label\` is required on '${this.id}'`, isString(this.label));
     assert(

--- a/packages/ember-principled-forms/addon/components/form-field/component.ts
+++ b/packages/ember-principled-forms/addon/components/form-field/component.ts
@@ -66,6 +66,9 @@ function parseValue(value: string, type: Type): string | number | boolean | Date
 export default class FormField<T> extends Component {
   id!: string;
   errorId!: string;
+  onChange!: (newValue: T) => void;
+  onInput!: (newValue: T) => void;
+  
   readonly label!: string;
   readonly model!: Field<T>;
 
@@ -94,21 +97,16 @@ export default class FormField<T> extends Component {
     return this.isInvalid ? this.errorId : undefined;
   }
 
-  onChange!: (newValue: T) => void;
-  onInput!: (newValue: T) => void;
-
   init() {
     super.init();
 
     // DISCUSS: What other useful defaults can we apply?
     // e.g. an ARIA object
     this.id = defaultTo(this.id, `form-field-${this.model.type}-${this.label}`);
-    this.errorId = defaultTo(
-      `${this.id}-error`,
-      `form-field-${this.model.type}-${this.label}-error`
-    );
+    this.errorId = defaultTo(this.errorId, `${this.id}-error`);
     this.onChange = defaultTo(this.onChange, noop);
     this.onInput = defaultTo(this.onInput, noop);
+
     assert(`\`model\` is required on '${this.id}'`, !isNone(this.model));
     assert(`\`label\` is required on '${this.id}'`, isString(this.label));
     assert(


### PR DESCRIPTION
Due to [updates in Ember 3.6](https://www.emberjs.com/blog/2019/01/26/emberjs-native-class-update-2019-edition.html#toc_code-constructor-code-vs-code-init-code) accessing `this.*` is not supported in `constructor`. Moved property initialization to `init`.